### PR TITLE
Make Slack notifications optional.

### DIFF
--- a/env.example.sh
+++ b/env.example.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+# Optional
+export SLACK_TOKEN=
+
+# Specify *one* of the following
 # export ADMIN_APIKEY=
 export DECONST_APIKEY=
 
+# Required: GitHub personal access token. Generate at https://github.com/settings/tokens
 export GITHUB_TOKEN=
-export SLACK_TOKEN=

--- a/submit.rb
+++ b/submit.rb
@@ -26,7 +26,6 @@ def validate!
 
   missing << '- ADMIN_APIKEY or DECONST_APIKEY' unless @admin_apikey or @existing_apikey
   missing << '- GITHUB_TOKEN' unless @github_access_token
-  missing << '- SLACK_TOKEN' unless @slack_travis_token
 
   unless missing.empty?
     $stderr.puts "Missing required configuration settings:"
@@ -145,8 +144,10 @@ def setup_travis key_parts
     sh "travis encrypt -r rackerlabs/#{@repo_name} --add env.global #{name}=#{value}"
   end
 
-  puts "Encrypting Slack token"
-  sh "travis encrypt -r rackerlabs/#{@repo_name} --add notifications.slack #{@slack_travis_token}"
+  if @slack_travis_token
+    puts "Encrypting Slack token"
+    sh "travis encrypt -r rackerlabs/#{@repo_name} --add notifications.slack #{@slack_travis_token}"
+  end
 end
 
 def readme_badge


### PR DESCRIPTION
If `SLACK_TOKEN` is not set, don't send notifications to the Slack channel.
